### PR TITLE
Adding operation IDs to OpenAPI spec

### DIFF
--- a/src/api.yaml
+++ b/src/api.yaml
@@ -8,6 +8,7 @@ servers:
 paths:
   /json:
     get:
+      operationId: getJsonData
       summary: Get current card data in JSON format.
       responses:
         "200":
@@ -20,6 +21,7 @@ paths:
                   $ref: "#/components/schemas/CreditCard"
   /csv:
     get:
+      operationId: getCsvData
       summary: Get current card data in CSV format.
       responses:
         "200":


### PR DESCRIPTION
For fun, I made a GPT instance to recommend credit cards to users ([link if you're curious](https://chat.openai.com/g/g-LBY9eehTA-credit-card-connoisseur)), but it requires an operation ID for each API method. This PR adds one for the GET methods in both the /json and /csv paths.

Thank you for a great tool, by the way! :)