### PR TITLE
Ensure only one instance of `push` workflow can run concurrently

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+
+concurrency:
+  # If this workflow is already running, wait for the previous iteration to complete. Otherwise, Serverless doesn't really know how to handle deploying when a deploy is in progress, and will error out.
+  group: ${{ github.workflow }}
+
 jobs:
   deploy:
     name: deploy


### PR DESCRIPTION
Protects against Serverless Framework erroring out if you try to do a deploy while one's already in progress. This has bit me before when merging several PRs very soon after one another.